### PR TITLE
Adding CI Docker Image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,41 @@
+# Version: 0.1
+
+#
+# We base our image from the alpine light image
+FROM ubuntu:jammy-20240125
+
+#
+# Environment variables needed for the
+# build system
+ENV TZ=Europe/London
+ENV DEBIAN_FRONTEND="noninteractive"
+ENV PATH="${PATH}:/usr/local/go/bin"
+
+#
+# Identify the maintainer of an image
+LABEL maintainer="matheusgarcia28@gmail.com"
+
+# install build dependencies 
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends --no-install-suggests \
+    ca-certificates \
+    git \
+    make \
+    pkg-config \
+    wget \
+    && wget https://go.dev/dl/go1.22.0.linux-amd64.tar.gz -P golang-install \
+    && cd golang-install \
+    && rm -rf /usr/local/go && tar -C /usr/local -xzf go1.22.0.linux-amd64.tar.gz \
+    && GOBIN=/usr/local/bin go install github.com/pressly/goose/v3/cmd/goose@v3.18.0 \
+    && GOBIN=/usr/local/bin go install github.com/a-h/templ/cmd/templ@v0.2.543 \
+    && apt-get remove -y wget \
+    && apt-get clean \  
+    && apt-get autoremove -y \
+    && apt-get autoremove --purge -y \
+    && go clean --cache \
+    && go clean --modcache \
+    && go clean --testcache \
+    && go clean --fuzzcache \
+    && rm -rf golang-install \
+    && rm -rf /var/lib/apt/lists/* \
+    && rm -rf /usr/lib/gcc/x86_64-linux-gnu/7*


### PR DESCRIPTION
Adding a docker image that contains golang 1.22, as well as Goose 3.18.0 and Templ 0.2.543.

The docker image can be found [here](https://hub.docker.com/layers/mattgomes28/urchin-golang/0.1/images/sha256-1a9fadd3070fd4256d3dfe0d0155382a4f3c05720177b39c9e031f46081376ef?context=repo).