### PR TITLE
Adding golang-ci to docker image (for linters)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
 
     runs-on: ubuntu-latest
     container:
-      image: mattgomes28/urchin-golang:0.1
+      image: mattgomes28/urchin-golang:0.2
       options: --user 1001
 
     steps:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-# Version: 0.1
+# Version: 0.2
 
 #
 # We base our image from the alpine light image
@@ -28,6 +28,9 @@ RUN apt-get update \
     && rm -rf /usr/local/go && tar -C /usr/local -xzf go1.22.0.linux-amd64.tar.gz \
     && GOBIN=/usr/local/bin go install github.com/pressly/goose/v3/cmd/goose@v3.18.0 \
     && GOBIN=/usr/local/bin go install github.com/a-h/templ/cmd/templ@v0.2.543 \
+    && wget https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh -P golangci-install \ 
+    && sh ./golangci-install/install.sh -b /usr/local/bin v1.56.2 \
+    && rm -rf ./golangci-install \
     && apt-get remove -y wget \
     && apt-get clean \  
     && apt-get autoremove -y \
@@ -39,3 +42,4 @@ RUN apt-get update \
     && rm -rf golang-install \
     && rm -rf /var/lib/apt/lists/* \
     && rm -rf /usr/lib/gcc/x86_64-linux-gnu/7*
+


### PR DESCRIPTION
`golangci-lint` has a bunch of very useful tools for linting Go code, specially:

- Unused code checks
- Code style checks
- Unchecked error returns
- Static analysis

...