### PR TITLE
Add the `air` go app to the docker container

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-# Version: 0.2
+# Version: 0.3
 
 #
 # We base our image from the alpine light image
@@ -28,6 +28,7 @@ RUN apt-get update \
     && rm -rf /usr/local/go && tar -C /usr/local -xzf go1.22.0.linux-amd64.tar.gz \
     && GOBIN=/usr/local/bin go install github.com/pressly/goose/v3/cmd/goose@v3.18.0 \
     && GOBIN=/usr/local/bin go install github.com/a-h/templ/cmd/templ@v0.2.543 \
+    && GOBIN=/usr/local/bin go install github.com/cosmtrek/air@v1.49.0 \
     && wget https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh -P golangci-install \ 
     && sh ./golangci-install/install.sh -b /usr/local/bin v1.56.2 \
     && rm -rf ./golangci-install \


### PR DESCRIPTION
Needed this fort the `docker-compose` incoming work