### PR TITLE
Make the image serving endpoint static

### DIFF
--- a/admin-app/image.go
+++ b/admin-app/image.go
@@ -16,7 +16,6 @@ import (
 )
 
 // TODO : need these endpoints
-// r.GET("/images/:id", getImageHandler(&database))
 // r.POST("/images", postImageHandler(&database))
 // r.DELETE("/images", deleteImageHandler(&database))
 func postImageHandler(app_settings common.AppSettings, database database.Database) func(*gin.Context) {

--- a/app/app.go
+++ b/app/app.go
@@ -29,8 +29,8 @@ func SetupRoutes(app_settings common.AppSettings, database database.Database) *g
 	addCachableHandler(r, "GET", "/images/:name", imageHandler, &cache, app_settings, database)
 	addCachableHandler(r, "GET", "/images", imagesHandler, &cache, app_settings, database)
 
-	// This endpoint should be used to fetch the images from the backend
-	r.GET("/data/images/:name", getImageHandler(app_settings, database))
+	// Static endpoint for image serving
+	r.Static("/images/data", app_settings.ImageDirectory)
 
 	// Add the pagination route as a cacheable endpoint
 	addCachableHandler(r, "GET", "/page/:num", homeHandler, &cache, app_settings, database)
@@ -38,6 +38,7 @@ func SetupRoutes(app_settings common.AppSettings, database database.Database) *g
 	// DO not cache as it needs to handlenew form values
 	r.POST("/contact-send", makeContactFormHandler())
 
+	// Where all the static files (css, js, etc) are served from
 	r.Static("/static", "./static")
 	return r
 }

--- a/app/image.go
+++ b/app/image.go
@@ -2,11 +2,8 @@ package app
 
 import (
 	"bytes"
-	"io"
-	"net/http"
 	"os"
 	"path"
-	"path/filepath"
 	"slices"
 	"strconv"
 
@@ -107,36 +104,4 @@ func imageHandler(c *gin.Context, app_settings common.AppSettings, database data
 	}
 
 	return html_buffer.Bytes(), nil
-}
-
-func getImageHandler(app_settings common.AppSettings, database database.Database) func(*gin.Context) {
-	return func(c *gin.Context) {
-		var get_image_binding common.ImageIdBinding
-		if err := c.ShouldBindUri(&get_image_binding); err != nil {
-			c.JSON(http.StatusBadRequest, common.ErrorRes("could not get image id", err))
-			return
-		}
-
-		// TODO : How do we get the filename?
-		image_path := filepath.Join(app_settings.ImageDirectory, get_image_binding.Filename)
-		file, err := os.Open(image_path)
-		if err != nil {
-			log.Error().Msgf("failed to load saved image: %v", err)
-			c.JSON(http.StatusNotFound, common.ErrorRes("image not found", err))
-			return
-		}
-
-		data, err := io.ReadAll(file)
-		if err != nil {
-			log.Error().Msgf("failed to load saved image: %v", err)
-			c.JSON(http.StatusNotFound, common.ErrorRes("image not found", err))
-			return
-		}
-
-		c.Data(http.StatusOK, getContentTypeFromData(data), data)
-	}
-}
-
-func getContentTypeFromData(data []byte) string {
-	return http.DetectContentType(data[:512])
 }

--- a/views/image.templ
+++ b/views/image.templ
@@ -23,11 +23,11 @@ templ MakeImagePage(image Image, links []Link) {
         <main>
             <article>
             <h3>{ image.Name }</h3>
-            <img src={fmt.Sprintf("/data/images/%s", image.Name)} alt={image.AltText} />
+            <img src={fmt.Sprintf("/images/data/%s", image.Name)} alt={image.AltText} />
             <p>{ image.AltText }</p>
             </article>
         </main>
-        <a href={templ.URL("/images")}>Back</a>
+        <a href={templ.URL("/images/data")}>Back</a>
     
         @MakeFooter()
     </body>

--- a/views/image.templ
+++ b/views/image.templ
@@ -27,7 +27,7 @@ templ MakeImagePage(image Image, links []Link) {
             <p>{ image.AltText }</p>
             </article>
         </main>
-        <a href={templ.URL("/images/data")}>Back</a>
+        <a href={templ.URL("/images")}>Back</a>
     
         @MakeFooter()
     </body>

--- a/views/images.templ
+++ b/views/images.templ
@@ -48,7 +48,7 @@ templ MakeImagesPage(images []Image, links []Link) {
                     for _, image := range images {
                         <a href={templ.URL("/images/" + image.Name)}>
                             <div>
-                                <img src={fmt.Sprintf("/data/images/%s", image.Name)} alt={image.AltText} />
+                                <img src={fmt.Sprintf("/images/data/%s", image.Name)} alt={image.AltText} />
                                 <span>{image.Name}</span>
                             </div>
                         </a>


### PR DESCRIPTION
Motives:

- Gin has the facilities to return correct content-type based on static file.
- Too much logic in the image middleware, hard to reason about the code.
- Less things to go wrong in the image code paths.