### PR TITLE
Allow Cache to be Disabled

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -47,10 +47,12 @@ func addCachableHandler(e *gin.Engine, method string, endpoint string, generator
 
 	handler := func(c *gin.Context) {
 		// if the endpoint is cached
-		cached_endpoint, err := (*cache).Get(c.Request.RequestURI)
-		if err == nil {
-			c.Data(http.StatusOK, "text/html; charset=utf-8", cached_endpoint.Contents)
-			return
+		if app_settings.CacheEnabled {
+			cached_endpoint, err := (*cache).Get(c.Request.RequestURI)
+			if err == nil {
+				c.Data(http.StatusOK, "text/html; charset=utf-8", cached_endpoint.Contents)
+				return
+			}
 		}
 
 		// Before handler call (retrieve from cache)
@@ -63,9 +65,11 @@ func addCachableHandler(e *gin.Engine, method string, endpoint string, generator
 		}
 
 		// After handler  (add to cache)
-		err = (*cache).Store(c.Request.RequestURI, html_buffer)
-		if err != nil {
-			log.Warn().Msgf("could not add page to cache: %v", err)
+		if app_settings.CacheEnabled {
+			err = (*cache).Store(c.Request.RequestURI, html_buffer)
+			if err != nil {
+				log.Warn().Msgf("could not add page to cache: %v", err)
+			}
 		}
 		c.Data(http.StatusOK, "text/html; charset=utf-8", html_buffer)
 	}

--- a/common/app_settings.go
+++ b/common/app_settings.go
@@ -17,6 +17,7 @@ type AppSettings struct {
 	WebserverPort    int    `toml:"webserver_port"`
 	AdminPort        int    `toml:"admin_port"`
 	ImageDirectory   string `toml:"image_dir"`
+	CacheEnabled     bool   `toml:"cache_enabled"`
 	AppNavbar        Navbar `toml:"navbar"`
 }
 

--- a/docker/urchin_config.toml
+++ b/docker/urchin_config.toml
@@ -23,6 +23,9 @@ admin_port = 8081
 # Directory to use for storing uploaded images.
 image_dir = "./images"
 
+# Enable/disable endpoint caching
+cache_enabled = true
+
 [navbar]
 links = [
     { name = "Home", href = "/", title = "Homepage" },

--- a/tests/app_tests/endpoint_tests/posts_test.go
+++ b/tests/app_tests/endpoint_tests/posts_test.go
@@ -21,6 +21,7 @@ func TestPostSuccess(t *testing.T) {
 		DatabasePassword: "root",
 		DatabaseName:     "urchin",
 		WebserverPort:    8080,
+		CacheEnabled:     false,
 	}
 
 	database_mock := mocks.DatabaseMock{
@@ -107,6 +108,7 @@ func TestPostFailureNegativeInvalidKey(t *testing.T) {
 		DatabasePassword: "root",
 		DatabaseName:     "urchin",
 		WebserverPort:    8080,
+		CacheEnabled:     false,
 	}
 
 	database_mock := mocks.DatabaseMock{

--- a/tests/helpers/helpers.go
+++ b/tests/helpers/helpers.go
@@ -88,6 +88,7 @@ func GetAppSettings(app_num int) common.AppSettings {
 		DatabasePassword: "",
 		DatabaseName:     "urchin",
 		WebserverPort:    8080,
+		CacheEnabled:     false,
 	}
 
 	return app_settings

--- a/urchin_config.toml
+++ b/urchin_config.toml
@@ -23,6 +23,9 @@ admin_port = 8081
 # Directory to use for storing uploaded images.
 image_dir = "./images"
 
+# Enable/disable endpoint cache
+cache_enabled = true
+
 [navbar]
 links = [
     { name = "Home", href = "/", title = "Homepage" },


### PR DESCRIPTION
* Simple config entry to provide a boolean flag.
* The 'addCachableHandler(...)' reads the flag and decides to ignore cache.
* Tests should by default not have the cache enabled, unless it's a caching test.