### PR TITLE
check if num_paths == 0 to avoid errors

### DIFF
--- a/common/image_utils.go
+++ b/common/image_utils.go
@@ -74,6 +74,9 @@ func GetImages(paths []string, page_size, page_num int, app_settings AppSettings
 	offset := (page_num - 1) * page_size
 
 	num_paths := len(paths)
+	if num_paths == 0 {
+		return []Image{}, nil
+	}
 	if offset >= num_paths {
 		return []Image{}, fmt.Errorf("invalid pagination settings: `page_size` (%d) and `page_num` (%d)", page_size, page_num)
 	}


### PR DESCRIPTION
if there are no images the page show an error: 
{
msg: "could not render HTML",
error: "invalid pagination settings: `page_size` (10) and `page_num` (1)"
}